### PR TITLE
fix(iOS): issue with setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ A NativeScript plugin to provide an XML widget to implement the Material Design 
 ```
 
 ## Attributes
+
+**Please note**: iOS uses default appearance settings and the `elevation` and `radius` cannot be set. The `backgroundColor` can be set though on both platforms (Android/iOS).
+
 **elevation** *optional*
 
  An attribute to set the elevation of the card. This will increase the 'drop-shadow' of the card.

--- a/cardview.ios.ts
+++ b/cardview.ios.ts
@@ -6,21 +6,21 @@ import {Property, PropertyMetadataSettings} from "ui/core/dependency-observable"
 
 global.moduleMerge(common, exports);
 
-var radiusProp = new Property(
-  "radius",
-  "CardView",
-  new PropertyMetadata(undefined, PropertyMetadataSettings.None)
-);
-var shadowOpacityProp = new Property(
-  "shadowOpacity",
-  "CardView",
-  new PropertyMetadata(undefined, PropertyMetadataSettings.None)
-);
-var shadowRadiusProp = new Property(
-  "shadowRadius",
-  "CardView",
-  new PropertyMetadata(undefined, PropertyMetadataSettings.None)
-);
+// var radiusProp = new Property(
+//   "radius",
+//   "CardView",
+//   new PropertyMetadata(undefined, PropertyMetadataSettings.None)
+// );
+// var shadowOpacityProp = new Property(
+//   "shadowOpacity",
+//   "CardView",
+//   new PropertyMetadata(undefined, PropertyMetadataSettings.None)
+// );
+// var shadowRadiusProp = new Property(
+//   "shadowRadius",
+//   "CardView",
+//   new PropertyMetadata(undefined, PropertyMetadataSettings.None)
+// );
 var backgroundColorProp = new Property(
   "backgroundColor",
   "CardView",
@@ -29,9 +29,9 @@ var backgroundColorProp = new Property(
 
 
 export class CardView extends common.CardView {
-  public radiusProp = radiusProp;
-  public shadowOpacityProp = shadowOpacityProp;
-  public shadowRadiusProp = shadowRadiusProp;
+  // public radiusProp = radiusProp;
+  // public shadowOpacityProp = shadowOpacityProp;
+  // public shadowRadiusProp = shadowRadiusProp;
   public backgroundColorProp = backgroundColorProp;
   private _ios: MaterialCardView;
 
@@ -62,26 +62,26 @@ export class CardView extends common.CardView {
     return this._ios;
   }
   
-  get radius(): string {
-    return this._getValue(this.radiusProp);
-  }
-  set radius(value: string) {
-    this._setValue(this.radiusProp, value);
-  }
+  // get radius(): string {
+  //   return this._getValue(this.radiusProp);
+  // }
+  // set radius(value: string) {
+  //   this._setValue(this.radiusProp, value);
+  // }
   
-  get shadowOpacity(): string {
-    return this._getValue(this.shadowOpacityProp);
-  }
-  set shadowOpacity(value: string) {
-    this._setValue(this.shadowOpacityProp, value);
-  }
+  // get shadowOpacity(): string {
+  //   return this._getValue(this.shadowOpacityProp);
+  // }
+  // set shadowOpacity(value: string) {
+  //   this._setValue(this.shadowOpacityProp, value);
+  // }
   
-  get shadowRadius(): string {
-    return this._getValue(this.shadowRadiusProp);
-  }
-  set shadowRadius(value: string) {
-    this._setValue(this.shadowRadiusProp, value);
-  }
+  // get shadowRadius(): string {
+  //   return this._getValue(this.shadowRadiusProp);
+  // }
+  // set shadowRadius(value: string) {
+  //   this._setValue(this.shadowRadiusProp, value);
+  // }
 
   get backgroundColor(): string {
     return this._getValue(this.backgroundColorProp);
@@ -93,20 +93,20 @@ export class CardView extends common.CardView {
   private updateAppearance() {
     // console.log('updateAppearance');
     
-    if (this.radius) {
-      // console.log(`radius: ${this.radius}`);  
-      this._ios.cardRadius = +this.radius;
-    }
+    // if (this.radius) {
+    //   // console.log(`radius: ${this.radius}`);  
+    //   this._ios.cardRadius = +this.radius;
+    // }
     
-    if (this.shadowOpacity) {
-      // console.log(`shadowOpacity: ${this.shadowOpacity}`);  
-      this._ios.shadowOpacity = +this.shadowOpacity;
-    }
+    // if (this.shadowOpacity) {
+    //   // console.log(`shadowOpacity: ${this.shadowOpacity}`);  
+    //   this._ios.shadowOpacity = +this.shadowOpacity;
+    // }
     
-    if (this.shadowRadius) {
-      // console.log(`shadowRadius: ${this.shadowRadius}`);  
-      this._ios.shadowRadius = +this.shadowRadius;
-    }
+    // if (this.shadowRadius) {
+    //   // console.log(`shadowRadius: ${this.shadowRadius}`);  
+    //   this._ios.shadowRadius = +this.shadowRadius;
+    // }
     
     if (this.backgroundColor) {
       // console.log(`backgroundColor: ${this.backgroundColor}`);  

--- a/demo/app/App_Resources/iOS/Info.plist
+++ b/demo/app/App_Resources/iOS/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -8,8 +8,8 @@ var viewModel = new observable.Observable({});
 
 export function pageLoaded(args: observable.EventData) {
     var page = <pages.Page>args.object;
-    var sl = frame.topmost().currentPage.getViewById('stack');
-    console.log('sl = ' + sl);
+    // var sl = frame.topmost().currentPage.getViewById('stack');
+    // console.log('sl = ' + sl);
     page.bindingContext = viewModel;
 }
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,7 +2,7 @@
 	"nativescript": {
 		"id": "org.nativescript.demo",
 		"tns-ios": {
-			"version": "1.5.2"
+			"version": "1.6.0"
 		},
 		"tns-android": {
 			"version": "1.5.1"
@@ -14,6 +14,6 @@
 	},
 	"devDependencies": {
 		"nativescript-dev-typescript": "^0.2.3",
-		"typescript": "^1.7.5"
+		"typescript": "^1.8.2"
 	}
 }


### PR DESCRIPTION
@bradmartin For time being, this disables custom settings for `radius` with iOS. There have been some issues discovered with the setters. Good news is the default appearance settings for `MaterialCardView` are adequate for the large majority. I would merge this, bump, and republish to ensure iOS users have a smooth experience with this plugin. 

I'll post another PR when/if I can get the setters straightened out.
