### PR TITLE
Using the status bar height can return invalid values when in landscape

### DIFF
--- a/cardview.ios.ts
+++ b/cardview.ios.ts
@@ -3,6 +3,7 @@ import {Color} from "color";
 import * as uiUtils from 'ui/utils';
 import {PropertyMetadata} from 'ui/core/proxy';
 import {Property, PropertyMetadataSettings} from 'ui/core/dependency-observable';
+import * as Platform from 'platform';
 
 declare var MaterialCard: any, UIApplication: any, CGRectMake: any;
 
@@ -11,8 +12,8 @@ export class CardView extends ContentView {
 
   constructor() {
     super();
- 
-    this._ios = new MaterialCard(CGRectMake(10, uiUtils.ios.getStatusBarHeight() + 10, UIApplication.sharedApplication().statusBarFrame.size.width - 20, 0));
+    let width = Platform.screen.mainScreen.widthDIPs - 20;
+    this._ios = new MaterialCard(CGRectMake(10, 30, width, 0));
 
     // Default values for MaterialCard    
     // radius = 2;


### PR DESCRIPTION
This will fix the issue when creating this on a device in Landscape mode.  StatusBar height on all iOS devices is a fixed 20 pixels.  So we are going to hard code this; since this value may be returned as 0, 20, 40, or 9999...   Width maybe returned as 0, or the height or the _width_ depending on orientation.  Since we really only want the width of the screen, we are switching to use the platform module to get screen width so that it is consistent.
