### PR TITLE
iOS refactor, removing the Swift-pod

### DIFF
--- a/cardview.ios.ts
+++ b/cardview.ios.ts
@@ -4,8 +4,7 @@ import {PropertyMetadata} from 'ui/core/proxy';
 import {Property, PropertyMetadataSettings} from 'ui/core/dependency-observable';
 import { screen } from 'platform';
 import * as uiUtils from 'ui/utils';
-import style = require("ui/styling/style");
-
+import style = require('ui/styling/style');
 
 declare var UIView: any, UIApplication: any, CGRectMake: any, CGSizeMake: any;
 

--- a/cardview.ios.ts
+++ b/cardview.ios.ts
@@ -7,22 +7,23 @@ import * as uiUtils from 'ui/utils';
 import style = require("ui/styling/style");
 
 
-declare var MaterialCard: any, UIApplication: any, CGRectMake: any;
+declare var UIView: any, UIApplication: any, CGRectMake: any, CGSizeMake: any;
 
 export class CardView extends ContentView {
-  private _ios: MaterialCard;
+  private _ios: UIView;
 
   constructor() {
     super();
     let width = screen.mainScreen.widthDIPs - 20;
-    this._ios = new MaterialCard(CGRectMake(10, 30, width, 0));
-
-    // Default values for MaterialCard    
-    // radius = 2;
-    // shadowOffsetWidth = 0;
-    // shadowOffsetHeight = 2;
-    // shadowColor = new Color('#000').ios
-    // shadowOpacity = 0.4;
+    this._ios = new UIView(CGRectMake(10, 30, width, 0));
+    this._ios.layer.masksToBounds = false;
+    
+    this.shadowColor = "black";
+    this.radius = "0";
+    this.shadowRadius = "1";
+    this.shadowOpacity = "0.2";
+    this.shadowOffsetHeight = "2";
+    this.shadowOffsetWidth = "0";
   }
 
   get ios(): any {
@@ -34,23 +35,27 @@ export class CardView extends ContentView {
   }
   
   set radius(value: string) {
-    this._ios.cornerRadius = +value;
+    this._ios.layer.cornerRadius = +value;
+  }
+
+  set shadowRadius(value: string) {
+    this._ios.layer.shadowRadius = +value;
   }
 
   set shadowOffsetWidth(value: string) {
-    this._ios.shadowOffsetWidth = +value;
+    this._ios.layer.shadowOffsetWidth = CGSizeMake(value, this._ios.layer.shadowOffset.height);
   }
 
   set shadowOffsetHeight(value: string) {
-    this._ios.shadowOffsetHeight = +value;
+    this._ios.layer.shadowOffsetHeight = CGSizeMake(this._ios.layer.shadowOffset.width, value);
   }
 
   set shadowColor(value: string) {
-    this._ios.shadowColor = new Color(value).ios;
+    this._ios.layer.shadowColor = new Color(value).ios.cgColor;
   }     
   
   set shadowOpacity(value: string) {
-    this._ios.shadowOpacity = +value;
+    this._ios.layer.shadowOpacity = +value;
   }
 
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export declare class CardView extends ContentView {
     android: any /* android.support.v7.widget.CardView */;
 
     /**
-     * Gets the native [ios widget](https://github.com/NathanWalker/MaterialCard) that represents the user interface for this component. Valid only when running on iOS.
+     * Gets the native [ios widget](UIView) that represents the user interface for this component. Valid only when running on iOS.
      */
     ios: any /* MaterialCard */;
 
@@ -19,6 +19,11 @@ export declare class CardView extends ContentView {
     * Gets or set the radius of the card view.
     */
     radius: any;
+
+    /**
+    * Gets or set the shadow radius of the card view.
+    */
+    shadowRadius: any;
 
     /** 
      * Gets or set the elevation of the card view.  ** Valid only when running on Android OS **

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,0 @@
-pod 'MaterialCard', '~> 1.1.4'


### PR DESCRIPTION
This is a iOS-only refactor to use native, built-in components to design the material-card-view.
Changes are:
* Removing the Podfile (Nothing wrong with the Pod, but since it was swift-based, this would add additional 20+ MB on our app size).
* Updated the ctor and properties to use `UIView.layer` to design the card-view.
* Added a new ios property `shadowRadius` to set the "spread" of the border shadow.