### PR TITLE
Update for NativeScript 3.0-rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ A NativeScript plugin to provide an XML widget to implement the Material Design 
 
 
 ## Installation
+
+##### NativeScript 2.x
+- `tns plugin add nativescript-cardview@^1.3.2`
+
+##### NativeScript 3+
 - `tns plugin add nativescript-cardview`
-- *Be sure to run a new build after adding plugins to avoid any issues. Here is a post with some details: https://bradmartin.net/2016/07/20/ahhh-this-nativescript-plugin-doesnt-work/*
+
+*Be sure to run a new build after adding plugins to avoid any issues. Here is a post with some details: https://bradmartin.net/2016/07/20/ahhh-this-nativescript-plugin-doesnt-work/*
   
 ## Vanilla NativeScript
 

--- a/cardview-common.ts
+++ b/cardview-common.ts
@@ -1,0 +1,101 @@
+import { Color } from "tns-core-modules/color";
+import { ContentView } from "tns-core-modules/ui/content-view";
+import { backgroundColorProperty, backgroundInternalProperty, Property } from "tns-core-modules/ui/core/view";
+
+export {
+  backgroundColorProperty, backgroundInternalProperty
+} from 'tns-core-modules/ui/core/view';
+
+/**
+ * Contains the CardView class, which represents a card view component.
+ */
+export class CardViewCommon extends ContentView {
+
+  /**
+   * Gets the native [android widget](https://developer.android.com/reference/android/support/v7/widget/CardView.html) that represents the user interface for this component. Valid only when running on Android OS.
+   */
+  android: any /* android.support.v7.widget.CardView */;
+
+  /**
+   * Gets the native [ios widget](UIView) that represents the user interface for this component. Valid only when running on iOS.
+   */
+  ios: any /* MaterialCard */;
+
+  /**
+   * Gets or set the radius of the card view.
+   */
+  radius: number;
+
+  /**
+   * Gets or set the elevation of the card view.  ** Valid only when running on Android OS **
+   */
+  elevation: number;
+
+  /**
+   * Gets or set the shadow radius of the card view.  ** Valid only when running on iOS **
+   */
+  shadowRadius: number;
+
+  /**
+   * Set the shadow offset width of the card view. ** Valid only when running on iOS **
+   */
+  shadowOffsetWidth: number;
+
+
+  /**
+   * Set the shadow offset height of the card view. ** Valid only when running on iOS **
+   */
+  shadowOffsetHeight: number;
+
+  /**
+   * Set the shadow color of the card view. ** Valid only when running on iOS **
+   */
+  shadowColor: string;
+
+  /**
+   * Set the shadow opacity of the card view. ** Valid only when running on iOS **
+   */
+  shadowOpacity: number;
+}
+
+export const radiusProperty = new Property<CardViewCommon, number>({
+  name: "radius",
+  valueConverter: value => +value
+});
+radiusProperty.register(CardViewCommon);
+
+export const elevationProperty = new Property<CardViewCommon, number>({
+  name: "elevation",
+  valueConverter: value => +value
+});
+elevationProperty.register(CardViewCommon);
+
+export const shadowRadiusProperty = new Property<CardViewCommon, number>({
+  name: "shadowRadius",
+  valueConverter: value => +value
+});
+shadowRadiusProperty.register(CardViewCommon);
+
+export const shadowOffsetWidthProperty = new Property<CardViewCommon, number>({
+  name: "shadowOffsetWidth",
+  valueConverter: value => +value
+});
+shadowOffsetWidthProperty.register(CardViewCommon);
+
+export const shadowOffsetHeightProperty = new Property<CardViewCommon, number>({
+  name: "shadowOffsetHeight",
+  valueConverter: value => +value
+});
+shadowOffsetHeightProperty.register(CardViewCommon);
+
+export const shadowColorProperty = new Property<CardViewCommon, Color>({
+  name: "shadowColor",
+  valueConverter: value => new Color(value)
+});
+shadowColorProperty.register(CardViewCommon);
+
+export const shadowOpacityProperty = new Property<CardViewCommon, number>({
+  name: "shadowOpacity",
+  valueConverter: value => +value
+});
+shadowOpacityProperty.register(CardViewCommon);

--- a/cardview.android.ts
+++ b/cardview.android.ts
@@ -1,73 +1,47 @@
-﻿import { ContentView } from 'ui/content-view';
-import { View } from "ui/core/view";
 import { Color } from "color";
-import style = require("ui/styling/style");
+import {
+  backgroundColorProperty, backgroundInternalProperty, CardViewCommon, elevationProperty, radiusProperty
+} from "./cardview-common";
 
 declare var android: any;
 
-export class CardView extends ContentView {
-  private _radius: number;
-  private _elevation: number;
+export class CardView extends CardViewCommon {
+
   private _androidViewId: number;
-  private _android: android.support.v7.widget.CardView;
 
   get android(): any {
-    return this._android;
+    return this.nativeView;
   }
 
-  get _nativeView(): any {
-    return this._android;
+  [radiusProperty.setNative](value: number) {
+    this.nativeView.setRadius(value);
   }
 
-  set radius(value: number) {
-    this._radius = value;
-    if (this._android)
-      this._android.setRadius(value);
+  [elevationProperty.setNative](value: number) {
+    this.nativeView.setCardElevation(value);
   }
 
-  set elevation(value: number) {
-    this._elevation = value;
-    if (this._android)
-      this._android.setCardElevation(value);
+  public createNativeView() {
+    return new android.support.v7.widget.CardView(this._context);
   }
 
-  public _createUI() {
-    this._android = new android.support.v7.widget.CardView(this._context);
+  public initNativeView() {
+    this._androidViewId = android.view.View.generateViewId();
+    this.nativeView.setId(this._androidViewId);
+  }
 
-    if (!this._androidViewId) {
-      this._androidViewId = android.view.View.generateViewId();
+  [backgroundColorProperty.setNative](value: Color) {
+    if (value) {
+      try {
+        this.nativeView.setCardBackgroundColor(value.android);
+      } catch (error) {
+        // do nothing, catch bad color value
+        console.log("bad background-color value:", error);
+      }
     }
-    this._android.setId(this._androidViewId);
+  }
 
-    if (this._radius || this._radius === 0)
-      this.radius = this._radius;
-
-    if (this._elevation || this._elevation === 0)
-      this.elevation = this._elevation;
+  [backgroundInternalProperty.setNative](value: any) {
+    //
   }
 }
-
-
-
-export class CardViewStyler implements style.Styler {
-
-  private static setBackgroundProperty(view: View, newValue: any) {
-    let card = <android.support.v7.widget.CardView>view.android;
-    let droidColor = new Color(newValue).android;
-    card.setCardBackgroundColor(droidColor);
-  }
-
-  private static resetBackgroundProperty(view: View, nativeValue: number) {
-    // do nothing.
-  }
-
-  public static registerHandlers() {
-    style.registerHandler(style.backgroundColorProperty, new style.StylePropertyChangedHandler(
-      CardViewStyler.setBackgroundProperty,
-      CardViewStyler.resetBackgroundProperty), "CardView");
-
-    style.registerHandler(style.backgroundInternalProperty, style.ignorePropertyHandler, "CardView");
-  }
-}
-
-CardViewStyler.registerHandlers();

--- a/cardview.ios.ts
+++ b/cardview.ios.ts
@@ -1,85 +1,52 @@
-import { ContentView } from "ui/content-view";
 import { Color } from "color";
 import { screen } from "platform";
-import style = require("ui/styling/style");
+import {
+  CardViewCommon, radiusProperty, shadowColorProperty, shadowOffsetHeightProperty, shadowOffsetWidthProperty,
+  shadowOpacityProperty, shadowRadiusProperty
+} from "./cardview-common";
 
-declare var UIView: any, UIApplication: any, CGRectMake: any, CGSizeMake: any;
+declare var UIView: any, CGRectMake: any, CGSizeMake: any;
 
-export class CardView extends ContentView {
-  private _ios: UIView;
+export class CardView extends CardViewCommon {
 
   constructor() {
     super();
     let width = screen.mainScreen.widthDIPs - 20;
-    this._ios = new UIView(CGRectMake(10, 30, width, 0));
-    this._ios.layer.masksToBounds = false;
+    this.nativeView = new UIView(CGRectMake(10, 30, width, 0));
+    this.nativeView.layer.masksToBounds = false;
     this.shadowColor = "black";
-    this.radius = "1";
-    this.shadowRadius = "1";
-    this.shadowOpacity = "0.4";
-    this.shadowOffsetHeight = "2";
-    this.shadowOffsetWidth = "0";
+    this.radius = 1;
+    this.shadowRadius = 1;
+    this.shadowOpacity = 0.4;
+    this.shadowOffsetHeight = 2;
+    this.shadowOffsetWidth = 0;
   }
 
   get ios(): any {
-    return this._ios;
+    return this.nativeView;
   }
 
-  get _nativeView(): any {
-    return this._ios;
+  [radiusProperty.setNative](value: number) {
+    this.nativeView.layer.cornerRadius = value;
   }
 
-  set radius(value: string) {
-    this._ios.layer.cornerRadius = +value;
+  [shadowRadiusProperty.setNative](value: number) {
+    this.nativeView.layer.shadowRadius = value;
   }
 
-  set shadowRadius(value: string) {
-    this._ios.layer.shadowRadius = +value;
+  [shadowOffsetWidthProperty.setNative](value: number) {
+    this.nativeView.layer.shadowOffset = CGSizeMake(value, this.nativeView.layer.shadowOffset.height);
   }
 
-  set shadowOffsetWidth(value: string) {
-    this._ios.layer.shadowOffset = CGSizeMake(+value, this._ios.layer.shadowOffset.height);
+  [shadowOffsetHeightProperty.setNative](value: number) {
+    this.nativeView.layer.shadowOffset = CGSizeMake(this.nativeView.layer.shadowOffset.width, value);
   }
 
-  set shadowOffsetHeight(value: string) {
-    this._ios.layer.shadowOffset = CGSizeMake(this._ios.layer.shadowOffset.width, +value);
+  [shadowColorProperty.setNative](value: Color) {
+    this.nativeView.layer.shadowColor = value.ios.CGColor;
   }
 
-  set shadowColor(value: string) {
-    this._ios.layer.shadowColor = new Color(value).ios.CGColor;
-  }
-
-  set shadowOpacity(value: string) {
-    this._ios.layer.shadowOpacity = +value;
-  }
-
-}
-
-export class CardViewStyler implements style.Styler {
-  private static setBackgroundProperty(view: any, newValue: any) {
-    if (view._nativeView) {
-      try {
-        // var color = new Color(newValue);
-        // console.log('setting background-color', color.ios);
-        view._nativeView.backgroundColor = newValue;
-      } catch (error) {
-        // do nothing, catch bad color value
-        console.log("bad background-color value:", error);
-      }
-    }
-  }
-
-  private static resetBackgroundProperty(view: any, nativeValue: number) {
-    // do nothing.
-  }
-
-  public static registerHandlers() {
-    style.registerHandler(style.backgroundColorProperty, new style.StylePropertyChangedHandler(
-      CardViewStyler.setBackgroundProperty,
-      CardViewStyler.resetBackgroundProperty), "CardView");
-
-    style.registerHandler(style.backgroundInternalProperty, style.ignorePropertyHandler, "CardView");
+  [shadowOpacityProperty.setNative](value: number) {
+    this.nativeView.layer.shadowOpacity = value;
   }
 }
-
-CardViewStyler.registerHandlers();

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -1,14 +1,14 @@
 /*
-In NativeScript, the app.ts file is the entry point to your application.
-You can use this file to perform app-level initialization, but the primary
-purpose of the file is to pass control to the app’s first module.
-*/
+ In NativeScript, the app.ts file is the entry point to your application.
+ You can use this file to perform app-level initialization, but the primary
+ purpose of the file is to pass control to the app’s first module.
+ */
 
-import * as app from 'application';
+import * as app from "application";
 
 app.start({ moduleName: 'main-page' });
 
 /*
-Do not place any code after the application has been started as it will not
-be executed on iOS.
-*/
+ Do not place any code after the application has been started as it will not
+ be executed on iOS.
+ */

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -1,7 +1,4 @@
-﻿import * as app from 'application';
-import {Color} from 'color';
-import * as platform from 'platform';
-import {Demo} from "./main-view-model";
+﻿import { Demo } from "./main-view-model";
 
 function pageLoaded(args) {
   var page = args.object;

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -1,8 +1,7 @@
-import * as frame from 'ui/frame';
-import * as app from 'application';
-import { Observable, EventData } from 'data/observable';
+import { EventData, Observable } from "data/observable";
+import { CardView } from "nativescript-cardview";
 import { isAndroid, isIOS } from "platform";
-import { CardView } from 'nativescript-cardview';
+import * as frame from "ui/frame";
 
 export class Demo extends Observable {
 
@@ -18,19 +17,19 @@ export class Demo extends Observable {
       opacity: 0,
       duration: 1000
     }).then(() => {
-      card.visibility = 'collapsed';
+      card.visibility = 'collapse';
     });
   }
 
   public goAwayJoker(args) {
     let page = frame.topmost().currentPage;
-    let card = page.getViewById('jokerCard');
+    let card = <CardView>page.getViewById('jokerCard');
     card.animate({
       scale: { x: 0, y: 0 },
       opacity: 0,
       duration: 1000
     }).then(() => {
-      card.visibility = 'collapsed';
+      card.visibility = 'collapse';
     });
   }
 
@@ -43,6 +42,4 @@ export class Demo extends Observable {
       console.log('card native ios = ' + card.ios);
     }
   }
-
 }
-

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,24 +1,24 @@
 {
   "nativescript": {
     "id": "org.nativescript.demo",
-    "tns-ios": {
-      "version": "2.4.0"
-    },
     "tns-android": {
-      "version": "2.5.0"
+      "version": "3.0.0-rc.1"
+    },
+    "tns-ios": {
+      "version": "3.0.0-rc.1-2017-3-28-2"
     }
   },
   "dependencies": {
     "nativescript-cardview": "file:..",
-    "tns-core-modules": "^2.4.4"
+    "tns-core-modules": "rc"
   },
   "devDependencies": {
-    "babel-traverse": "6.8.0",
-    "babel-types": "6.8.1",
-    "babylon": "6.7.0",
+    "babel-traverse": "^6.24.1",
+    "babel-types": "^6.24.1",
+    "babylon": "^6.16.1",
     "filewalker": "0.1.2",
     "lazy": "1.0.11",
-    "nativescript-dev-typescript": "^0.3.2",
-    "typescript": "^2.0.9"
+    "nativescript-dev-typescript": "^0.4.2",
+    "typescript": "^2.2.2"
   }
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,10 +1,22 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "moduleResolution": "node",
         "target": "es5",
         "inlineSourceMap": true,
         "experimentalDecorators": true,
-        "noEmitHelpers": true
+        "noEmitHelpers": true,
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ]
+        }
     },
     "exclude": [
         "node_modules",

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,55 +1,53 @@
-import { ContentView } from 'ui/content-view';
+import { ContentView } from "ui/content-view";
+
 /**
  * Contains the CardView class, which represents a card view component.
  */
+export class CardView extends ContentView {
 
-export declare class CardView extends ContentView {
+  /**
+   * Gets the native [android widget](https://developer.android.com/reference/android/support/v7/widget/CardView.html) that represents the user interface for this component. Valid only when running on Android OS.
+   */
+  android: any /* android.support.v7.widget.CardView */;
 
-    /**
-      * Gets the native [android widget](https://developer.android.com/reference/android/support/v7/widget/CardView.html) that represents the user interface for this component. Valid only when running on Android OS.
-      */
-    android: any /* android.support.v7.widget.CardView */;
+  /**
+   * Gets the native [ios widget](UIView) that represents the user interface for this component. Valid only when running on iOS.
+   */
+  ios: any /* MaterialCard */;
 
-    /**
-     * Gets the native [ios widget](UIView) that represents the user interface for this component. Valid only when running on iOS.
-     */
-    ios: any /* MaterialCard */;
+  /**
+   * Gets or set the radius of the card view.
+   */
+  radius: number;
 
-    /**
-    * Gets or set the radius of the card view.
-    */
-    radius: any;
+  /**
+   * Gets or set the elevation of the card view.  ** Valid only when running on Android OS **
+   */
+  elevation: number;
 
-    /**
-    * Gets or set the shadow radius of the card view.
-    */
-    shadowRadius: any;
+  /**
+   * Gets or set the shadow radius of the card view.  ** Valid only when running on iOS **
+   */
+  shadowRadius: number;
 
-    /** 
-     * Gets or set the elevation of the card view.  ** Valid only when running on Android OS **
-     */
-    elevation: number;
-
-    /**
-     * Set the shadow offset height of the card view. ** Valid only when running on iOS **
-     */
-    shadowOffsetWidth: string;
+  /**
+   * Set the shadow offset width of the card view. ** Valid only when running on iOS **
+   */
+  shadowOffsetWidth: number;
 
 
-    /**
-     * Set the shadow offset height of the card view. ** Valid only when running on iOS **
-     */
-    shadowOffsetHeight: string;
+  /**
+   * Set the shadow offset height of the card view. ** Valid only when running on iOS **
+   */
+  shadowOffsetHeight: number;
 
-    /**
-     * Set the shadow color of the card view. ** Valid only when running on iOS **
-     */
-    shadowColor: string;
+  /**
+   * Set the shadow color of the card view. ** Valid only when running on iOS **
+   */
+  shadowColor: string;
 
-    /**
-     * Set the shadow opacity of the card view. ** Valid only when running on iOS **
-     */
-    shadowOpacity: string;
-
+  /**
+   * Set the shadow opacity of the card view. ** Valid only when running on iOS **
+   */
+  shadowOpacity: number;
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cardview",
-  "version": "1.3.2",
+  "version": "2.0.0-rc.0",
   "description": "A NativeScript plugin for Material Design CardView component.",
   "main": "cardview",
   "typings": "index.d.ts",
@@ -70,6 +70,9 @@
   "license": "Apache-2.0",
   "bugs": "https://github.com/bradmartin/nativescript-cardview/issues",
   "homepage": "https://github.com/bradmartin/nativescript-cardview",
+  "peerDependencies": {
+    "tns-core-modules": ">=3.0.0 || >=3.0.0-rc.1 || >=3.0.0-2017"
+  },
   "devDependencies": {
     "tns-core-modules": "3.0.0-rc.2"
   }

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
   "author": "Brad Martin <bradwaynemartin@gmail.com> (https://github.com/bradmartin)",
   "license": "Apache-2.0",
   "bugs": "https://github.com/bradmartin/nativescript-cardview/issues",
-  "homepage": "https://github.com/bradmartin/nativescript-cardview"
+  "homepage": "https://github.com/bradmartin/nativescript-cardview",
+  "devDependencies": {
+    "tns-core-modules": "3.0.0-rc.2"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,25 @@
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",
+        "moduleResolution": "node",
         "removeComments": true,
         "experimentalDecorators": true,
         "sourceMap": true,
-        "noEmitOnError": false
+        "noEmitOnError": false,
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ]
+        }
     },
     "files": [
-      "demo/node_modules/tns-core-modules/tns-core-modules.d.ts",
+      "cardview-common.ts",
       "cardview.android.ts",
       "cardview.ios.ts"
     ],


### PR DESCRIPTION
**Configured as detailed here:**
[NativeScript v3.0 Breaking Changes](https://github.com/NativeScript/NativeScript/blob/master/Modules30Changes.md#property-system)

**Notes:**
1. _nativeView field removed since nativeView is now part of the API.
2. Stricter types for properties.
3. Otherwise should be backwards compatible with standard templates/css usage. (I didn't need to change any of my own or the demo templates/css.)
4. Tested with both Vanilla NativeScript Demo (.ts minimally updated per 3.0 changes) and with my own NS+ng project.

Obviously may be some changes before 3.0-release, but should remain close enough since I followed the example in the change log as well as other examples in the master repo, and works for my current project being built against Nativescript 3.0-rc and nativescript-angular 2.0-rc.