### PR TITLE
Fixed color undefined issue for NativeScript 3.1 when navigating (#65)

### DIFF
--- a/cardview.android.ts
+++ b/cardview.android.ts
@@ -36,7 +36,9 @@ export class CardView extends CardViewCommon {
   [backgroundColorProperty.setNative](value: Color) {
     if (value) {
       try {
-        this.nativeView.setCardBackgroundColor(value.android);
+        this.nativeView.setCardBackgroundColor(
+          value !== undefined ? value.android : new Color("#FFFFFF").android
+        );
       } catch (error) {
         // do nothing, catch bad color value
         console.log("bad background-color value:", error);
@@ -48,7 +50,8 @@ export class CardView extends CardViewCommon {
     if (value) {
       try {
         this.nativeView.setCardBackgroundColor(
-          new Color(value.color + "").android
+          new Color(value.color !== undefined ? value.color + "" : "#FFFFFF")
+            .android
         );
       } catch (error) {
         // do nothing, catch bad color value

--- a/cardview.ios.ts
+++ b/cardview.ios.ts
@@ -41,11 +41,14 @@ export class CardView extends CardViewCommon {
   }
 
   [backgroundColorProperty.setNative](value: Color) {
-    this.nativeView.backgroundColor = value.ios;
+    this.nativeView.backgroundColor =
+      value !== undefined ? value.ios : new Color("#FFFFFF").ios;
   }
 
   [backgroundInternalProperty.setNative](value) {
-    this.nativeView.backgroundColor = new Color(value.color + "").ios;
+    this.nativeView.backgroundColor = new Color(
+      value.color !== undefined ? value.color + "" : "#FFFFFF"
+    ).ios;
   }
 
   [shadowRadiusProperty.setNative](value: number) {


### PR DESCRIPTION
This PR fixes the issue that occurs in NativeScript 3.1 when you navigate away from a page using clearHistory (#65)