### PR TITLE
Support tns code modules 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,13 +86,13 @@
   "bugs": "https://github.com/bradmartin/nativescript-cardview/issues",
   "homepage": "https://github.com/bradmartin/nativescript-cardview",
   "peerDependencies": {
-    "tns-core-modules": "~3.2.0"
+    "tns-core-modules": "^3.2.0"
   },
   "devDependencies": {
     "husky": "^0.13.4",
     "lint-staged": "^3.6.1",
     "prettier": "^1.4.4",
-    "tns-core-modules": "~3.2.0",
+    "tns-core-modules": "^3.2.0",
     "tns-platform-declarations": "~3.2.0",
     "typescript": "2.5.2"
   }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "bugs": "https://github.com/bradmartin/nativescript-cardview/issues",
   "homepage": "https://github.com/bradmartin/nativescript-cardview",
   "peerDependencies": {
-    "tns-core-modules": "^3.2.0"
+    "tns-core-modules": "~3.3.0"
   },
   "devDependencies": {
     "husky": "^0.13.4",


### PR DESCRIPTION
Without this, it is not letting the installation of tns-core-modules 3.3.0
<img width="711" alt="screen shot 2017-10-27 at 3 03 06 pm" src="https://user-images.githubusercontent.com/9407019/32097746-25400ef6-bb28-11e7-9593-41724a3a968a.png">
