### PR TITLE
Fix for https://github.com/bradmartin/nativescript-cardview/issues/89

### DIFF
--- a/src/cardview.android.ts
+++ b/src/cardview.android.ts
@@ -35,7 +35,7 @@ export class CardView extends CardViewCommon {
       let attr = java.lang.Class.forName("android.support.v7.appcompat.R$attr");
       let field = attr.getField("selectableItemBackground");
       
-      if( field ) {
+      if( field && android.os.Build.VERSION.SDK_INT >= 23  ) {
         let resId = field.getInt(null);
 
         let attrs =  Array.create("int", 1);

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cardview",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A NativeScript plugin for Material Design CardView component.",
   "main": "cardview",
   "typings": "index.d.ts",


### PR DESCRIPTION
On API level 22, setting up the ripple causes a crash. This fix disables the ripple for 22 or lower.