### PR TITLE
fix: make the plugin androidx compatible

### DIFF
--- a/src/cardview.android.ts
+++ b/src/cardview.android.ts
@@ -10,7 +10,13 @@ import {
   radiusProperty,
   rippleProperty
 } from './cardview-common';
+declare let global: any;
+const CardViewNamespace = useAndroidX() ? global.androidx.cardview.widget : android.support.v7.widget;
+const AppCompatResourcesNamespace = useAndroidX() ? 'androidx.appcompat' : 'android.support.v7.appcompat';
 
+function useAndroidX() {
+  return global.androidx && global.androidx.cardview;
+}
 export class CardView extends CardViewCommon {
   private _androidViewId: number;
   public nativeView;
@@ -31,7 +37,8 @@ export class CardView extends CardViewCommon {
     if (!value) {
       this.nativeView.setClickable(false);
     } else {
-      const attr = java.lang.Class.forName('android.support.v7.appcompat.R$attr');
+      const resourcesUri = AppCompatResourcesNamespace + '.R$attr';
+      const attr = java.lang.Class.forName(resourcesUri);
 
       // https://developer.android.com/reference/java/lang/Class#getField(java.lang.String)
       const field = attr.getField('selectableItemBackground') as java.lang.reflect.Field;
@@ -51,7 +58,7 @@ export class CardView extends CardViewCommon {
   }
 
   public createNativeView() {
-    return new (android.support.v7.widget as any).CardView(this._context);
+    return new CardViewNamespace.CardView(this._context);
   }
 
   public initNativeView() {


### PR DESCRIPTION
As this plugin uses the old Android Support Libraries, it will not be compatible with the upcoming NativeScript 6.0 release which will use [AndroidX by default](https://www.nativescript.org/blog/support-for-androidx-in-nativescript). The changes from this PR make the plugin compatible with the AndroidX library (NS 6.0) and with the old libraries (NS before 6.0).